### PR TITLE
Extended the interface of supplying  parameters

### DIFF
--- a/lib/sendmail.js
+++ b/lib/sendmail.js
@@ -4,8 +4,8 @@ var mailer = require('nodemailer');
 
 
 module.exports = function(turl) {
-  var url = require('url').parse(turl||""), transport, host, port, auth, from, protocol, sysopts,
-  parts, domain;
+  var url = require('url').parse(turl||"", true), transport, host, port, auth, from, protocol, sysopts,
+  parts, domain, secure;
   // do we have a proper URL?
   url.protocol = url.protocol || "smtp:";
   url.host = url.host || "localhost";
@@ -17,8 +17,9 @@ module.exports = function(turl) {
   port = parseInt(url.port,10);
   parts = url.path.split(/\//);
   domain = parts[1];
+  secure = url.query['secureConnection'] || false;
   from = unescape(parts[2]);
-  sysopts = {host: host, port:port, name: domain};
+  sysopts = { host: host, port:port, name: domain, secureConnection: secure };
   if (url.auth) {
     auth = url.auth.split(":");
     sysopts.auth = {user:auth[0],pass:auth[1]};


### PR DESCRIPTION
Hi,
...Now, the secureConnection option can be set for the node mailer.

My mail service provider seems not to work without specifying the secureConnection for the node mailer. I'd guess that I'm not alone with this.

The change can be generalized later if needed. Now, you can set the added parameter in the URL as a query (...url_part/?secureConnection=true).  

Take care,
Panu
