### PR TITLE
bug: impossible to use a nodemailer transport

### DIFF
--- a/lib/sendmail.js
+++ b/lib/sendmail.js
@@ -11,7 +11,7 @@ module.exports = function(turl) {
 	  url.host = url.host || "localhost";
 	  url.port = url.port || "25";
 	  url.path = url.path || "/localhost";
-  
+
 	  protocol = url.protocol.replace(/:$/,"").toUpperCase();
 	  host = url.host.split(":")[0];
 	  port = parseInt(url.port,10);
@@ -25,13 +25,10 @@ module.exports = function(turl) {
 	  }
 
 	  // create reusable transport method (opens pool of SMTP connections)
-	  transport = mailer.createTransport(sysopts);		
+	  transport = mailer.createTransport(sysopts);
 	} else {
-		transport = turl;
+		transport = mailer.createTransport(turl);
 	}
-
-  // create reusable transport method (opens pool of SMTP connections)
-  transport = mailer.createTransport(sysopts);
 
   return function(from,to,subject,text,html,cb) {
     var opts = {


### PR DESCRIPTION
transport = mailer.createTransport(sysopts); was still called even if typeof(turl) !== 'string'
turl cannot be use directly but must be used to configure the mailer => transport = mailer.createTransport(turl)
