### PR TITLE
Don't allow to update user's password with reset token from another user

### DIFF
--- a/lib/activator.js
+++ b/lib/activator.js
@@ -164,7 +164,7 @@ completePasswordReset = function (req,done) {
 			} else {
 				try {
 					var decoded = jwt.verify(reset_code,signkey,{algorithms:"HS256"});
-					if (decoded.purpose !== "resetpassword") {
+					if (decoded.purpose !== "resetpassword" || decoded.sub !== getObjectProperty(res, emailProperty)) {
 						throw new Error("invalidresetcode");
 					} else if (decoded.iat < now - resetExpire*60) {
 						throw new Error("expiredresetcode");

--- a/test/test.js
+++ b/test/test.js
@@ -498,6 +498,32 @@ allTests = function () {
 					}
 				],done);
 			});
+			it('should fail when trying to update password of another user', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordreset').type('json').send({user:"1"}).expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordreset/'+users["2"].id).set({"Authorization":"Bearer "+res.code}).type('json').send({password:"abcdefgh"}).expect(400,cb);
+						});
+					}
+				],done);
+			});
+			it('should fail when trying to update password of another user with handler', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordresetnext').type('json').send({user:"1"}).expect('activator','createResetHandler').expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordresetnext/'+users["2"].id).set({"Authorization":"Bearer "+res.code}).type('json').send({password:"abcdefgh"}).expect('activator','completeResetHandler').expect(400,cb);
+						});
+					}
+				],done);
+			});
 			it('should succeed for known ID', function(done){
 				var email = users["1"].email, handler;
 				async.waterfall([
@@ -622,6 +648,32 @@ allTests = function () {
 					}
 				],done);
 			});
+			it('should fail when trying to update password of another user', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordreset').type('json').send({user:"1"}).expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordreset/'+users["2"].id).query({Authorization:res.code}).type('json').send({password:"abcdefgh"}).expect(400,cb);
+						});
+					}
+				],done);
+			});
+			it('should fail when trying to update password of another user with handler', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordresetnext').type('json').send({user:"1"}).expect('activator','createResetHandler').expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordresetnext/'+users["2"].id).query({Authorization:res.code}).type('json').send({password:"abcdefgh"}).expect('activator','completeResetHandler').expect(400,cb);
+						});
+					}
+				],done);
+			});
 			it('should succeed for known ID', function(done){
 				var email = users["1"].email, handler;
 				async.waterfall([
@@ -743,6 +795,32 @@ allTests = function () {
 						// create a new code but signed with a different time
 						var code = changeResetTime(res.code,-100);
 						r.put('/passwordresetnext/'+res.user).type("json").send({Authorization:code,password:"abcdefgh"}).expect('activator','completeResetHandler').expect(400,cb);
+					}
+				],done);
+			});
+			it('should fail when trying to update password of another user', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordreset').type('json').send({user:"1"}).expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordreset/'+users["2"].id).type('json').send({Authorization:res.code,password:"abcdefgh"}).expect(400,cb);
+						});
+					}
+				],done);
+			});
+			it('should fail when trying to update password of another user with handler', function(done){
+				var user = users["1"], email = user.email, handler;
+				async.waterfall([
+					function (cb) {r.post('/passwordresetnext').type('json').send({user:"1"}).expect('activator','createResetHandler').expect(201,cb);},
+					function (res,cb) {handler = rHandler(email,cb); mail.bind(email,handler);},
+					function (res,cb) {
+						createUser({}, {}, function() {
+							mail.unbind(email,handler);
+							r.put('/passwordresetnext/'+users["2"].id).type('json').send({Authorization:res.code,password:"abcdefgh"}).expect('activator','completeResetHandler').expect(400,cb);
+						});
 					}
 				],done);
 			});


### PR DESCRIPTION
Currently it's possible to reset any user's password with any valid reset token:

1) User №1 asks for reset password token on password reset page
2) He uses obtained token to make request like this (only need to know ID of victim):

```
http POST http://example.com/reset_password 
          password=swordfish
          authorization=<reset password token of user №1>
          user=<ID of user №2 (victim)>`
```
3) User's №2 password gets successfully updated

Previously `activator` was checking only for purpose and expiration time of reset code. This PR introduces an additional check to ensure that initiator of password reset could update only his own password.