### PR TITLE
Send password

### DIFF
--- a/lib/activator.js
+++ b/lib/activator.js
@@ -14,7 +14,7 @@ getObjectProperty = function(object, property) {
 	return current;
 },
 DEFAULTS = {
-	model: {find: function(user,cb){cb("uninitialized");}, save: function(id,data,cb){cb("uninitialized");}, generate: null },
+	model: {find: function(user,cb){cb("uninitialized");}, save: function(id,data,cb){cb("uninitialized");}, generate: null, check: null },
 	transport: "smtp://localhost:465/activator.net/",
 	templates: __dirname+'/templates',
 	resetExpire: 60,
@@ -162,6 +162,7 @@ completePasswordReset = function (req,done) {
 		function (res,cb) {
 			if (!res) {
 				cb(404);
+				return;
 			}
 
 			var password;
@@ -176,7 +177,15 @@ completePasswordReset = function (req,done) {
 				password = req.param("password");
 			}
 
+			if ((typeof(model.check) === "function") &&
+					!model.check(req, res, password)) {
+				/* Password is inappropriate */
+				cb("badpassword");
+				return;
+			}
+
 			if (!password) {
+				/* Password is missing */
 				cb("missingpassword");
 			} else {
 				try {

--- a/lib/activator.js
+++ b/lib/activator.js
@@ -23,7 +23,8 @@ DEFAULTS = {
 	from: "help@activator.net",
 	styliner: false,
 	attachments: {},
-	idProperty: "id"
+	idProperty: "id",
+	notifyOnNewPassword: false,
 },
 model = DEFAULTS.model, 
 transport, 
@@ -31,7 +32,7 @@ from,
 templates,
 emailProperty,
 idProperty,
-resetExpire, proto,
+resetExpire, proto, notifyOnNewPassword,
 getAuthCode = function (req) {
 	// first check for Authorization header
 	var ret, header = req.headers.Authorization || req.headers.authorization, lparam = req.param("authorization"),
@@ -195,7 +196,18 @@ completePasswordReset = function (req,done) {
 					} else if (decoded.iat < now - resetExpire*60) {
 						throw new Error("expiredresetcode");
 					}
-					model.setPassword(idProperty?getObjectProperty(res, idProperty):id,password,cb);
+					var onChange = cb;
+					if (notifyOnNewPassword) {
+						var email = getObjectProperty(res, emailProperty);
+						onChange = function(res) {
+							if (res === null) {
+								mailer("newpassword",req.lang||"en_US",{email:email,id:id,password:password,request:req},from,email,attachments.newpassword,cb);
+							} else {
+								cb(res);
+							}
+						};
+					}
+					model.setPassword(idProperty?getObjectProperty(res, idProperty):id,password,onChange);
 				} catch (e) {
 					cb(e);
 				}
@@ -229,6 +241,7 @@ module.exports = {
 		from = config.from || DEFAULTS.from;
 		idProperty = config.id || DEFAULTS.idProperty;
 		signkey = config.signkey;
+		notifyOnNewPassword = config.notifyOnNewPassword || DEFAULTS.notifyOnNewPassword;
 	},
 	createPasswordReset: function (req,res,next) {
 		rparam(req);

--- a/lib/activator.js
+++ b/lib/activator.js
@@ -14,7 +14,7 @@ getObjectProperty = function(object, property) {
 	return current;
 },
 DEFAULTS = {
-	model: {find: function(user,cb){cb("uninitialized");}, save: function(id,data,cb){cb("uninitialized");}},
+	model: {find: function(user,cb){cb("uninitialized");}, save: function(id,data,cb){cb("uninitialized");}, generate: null },
 	transport: "smtp://localhost:465/activator.net/",
 	templates: __dirname+'/templates',
 	resetExpire: 60,
@@ -156,13 +156,27 @@ createPasswordReset = function (req,done) {
 	});	
 },
 completePasswordReset = function (req,done) {
-	var reset_code = getAuthCode(req), password = req.param("password"), id = req.param("user"), now = Math.floor(new Date().getTime()/1000);
+	var reset_code = getAuthCode(req), id = req.param("user"), now = Math.floor(new Date().getTime()/1000);
 	async.waterfall([
 		function (cb) {model.find(id,cb);},
 		function (res,cb) {
 			if (!res) {
 				cb(404);
-			} else if (!password) {
+			}
+
+			var password;
+			if (typeof(model.generate) === "function") {
+				/*
+				 * Generate a password for the given user
+				 * and given request parameters.
+				 */
+				password = model.generate(req, res);
+			} else {
+				/* Use the user-supplied password */
+				password = req.param("password");
+			}
+
+			if (!password) {
 				cb("missingpassword");
 			} else {
 				try {


### PR DESCRIPTION
This sends the new password to the user after changing it.  The template can optionally include the password thus can be used either to tell the user their new password, or just to tell them that the password has been reset (in case they weren't aware of it).

The feature is turned on by setting the `notifyOnNewPassword` flag in the module configuration.